### PR TITLE
Added system dependencies to manifest

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -13,7 +13,8 @@
   <depend package="std_msgs"/>
   <depend package="geometry_msgs"/>
   <depend package="tf"/>
-
+  <rosdep name="libsndfile1-dev"/>
+  <rosdep name="libpng12-dev"/>
 </package>
 
 


### PR DESCRIPTION
This change lets you use rosdep install to install libsndfile1-dev and libpng12-dev.
